### PR TITLE
Fix for overrun of importCssString in shadod dom behavior for when th…

### DIFF
--- a/ace-widget-shadow-dom.html
+++ b/ace-widget-shadow-dom.html
@@ -95,7 +95,6 @@ A behavior to allow ace-edit to work under ShadowDom. If the app is in ShadowDOM
         var Editor = {
           setTheme: EditorHook.prototype.setTheme
         }
-        var cacheThis = this;
         EditorHook.prototype.setTheme = function() {
           Editor.setTheme.apply(this, arguments);
         }

--- a/ace-widget-shadow-dom.html
+++ b/ace-widget-shadow-dom.html
@@ -6,8 +6,7 @@ Inspired by [ace-shim-about-shadow-dom project](https://github.com/valaxy/ace-sh
 A behavior to allow ace-edit to work under ShadowDom. If the app is in ShadowDOM mode, it copies ace-editor's styles into the component ShadowDOM.
 -->
 <script>
-
- var AceWidgetShadowDom = (function(){
+  var AceWidgetShadowDom = (function() {
     var aceShadowRoots = [];
     var AceWidgetShadowDom = {
       // Properties
@@ -20,49 +19,51 @@ A behavior to allow ace-edit to work under ShadowDom. If the app is in ShadowDOM
         },
       },
 
-      init: function() { 
-        // console.log("Shadow", window.Polymer.Settings)       
-        if (window.Polymer.Settings.dom === 'shadow' || window.Polymer.Settings.useShadow ) {        
+      init: function() {
+        // console.log("Shadow", window.Polymer.Settings)
+        if (window.Polymer.Settings.dom === 'shadow' || window.Polymer.Settings.useShadow) {
           aceShadowRoots.push(Polymer.dom(this.root));
-          this._hookDom();
+          // Only need to hook the dom the first time a component is loaded
+          if (aceShadowRoots.length < 2) {
+            this._hookDom();
+          }
           this._getStyle();
           this._hookEditor();
           this._fixStyle();
         }
-      }, 
+      },
 
       _hookDom: function() {
-        var root = this.root;
-
         this._domHook = ace.require('ace/lib/dom')
         var dom = {
           getDocumentHead: this._domHook.getDocumentHead,
           importCssString: this._domHook.importCssString,
-          hasCssString   : this._domHook.hasCssString
+          hasCssString: this._domHook.hasCssString
         }
 
         var docHook = {
-          createElement : document.createElement.bind(document),
+          createElement: document.createElement.bind(document),
           createTextNode: document.createTextNode.bind(document),
-          cssHead       : null // change by importCssString
+          cssHead: null // change by importCssString
         }
-        this._domHook.getDocumentHead = function (doc) {
+        this._domHook.getDocumentHead = function(doc) {
           if (doc === docHook) {
             return docHook.cssHead;
           }
           return dom.getDocumentHead.apply(doc, arguments);
         }
 
-        this._domHook.hasCssString = function (id, doc) {
+        this._domHook.hasCssString = function(id, doc) {
           if (doc === docHook) {
-            var index = 0, sheets;
+            var index = 0,
+              sheets;
             doc = docHook.cssHead || document;
             if (doc.createStyleSheet && (sheets = doc.styleSheets)) {
-                while (index < sheets.length)
-                    if (sheets[index++].owningElement.id === id) return true;
+              while (index < sheets.length)
+                if (sheets[index++].owningElement.id === id) return true;
             } else if ((sheets = Polymer.dom(doc).querySelectorAll(("style")))) {
-                while (index < sheets.length)
-                    if (sheets[index++].id === id) return true;
+              while (index < sheets.length)
+                if (sheets[index++].id === id) return true;
             }
 
             return false;
@@ -70,13 +71,13 @@ A behavior to allow ace-edit to work under ShadowDom. If the app is in ShadowDOM
           }
           return dom.hasCssString(id, doc);
         }
-        this._domHook.importCssString = function (cssText, id, doc) { 
+        this._domHook.importCssString = function(cssText, id, doc) {
           var result
-			    aceShadowRoots.forEach(function (cssHead) {
-				    docHook.cssHead = cssHead
-				    result = dom.importCssString.call(this, cssText, id, docHook)
-			    })
-			    return result
+          aceShadowRoots.forEach(function(cssHead) {
+            docHook.cssHead = cssHead
+            dom.importCssString.call(this, cssText, id, docHook);
+          })
+          return result
         }
       },
       _getStyle: function() {
@@ -85,30 +86,30 @@ A behavior to allow ace-edit to work under ShadowDom. If the app is in ShadowDOM
         var style3 = style2.nextSibling;
 
         this._styles = [style1, style2, style3];
-        this._styles.forEach(function (style) {
-         //  style.parentNode.removeChild(style)
-        });      
+        this._styles.forEach(function(style) {
+          //  style.parentNode.removeChild(style)
+        });
       },
       _hookEditor: function() {
         var EditorHook = ace.require('ace/editor').Editor;
         var Editor = {
           setTheme: EditorHook.prototype.setTheme
         }
-
-        EditorHook.prototype.setTheme = function () {
+        var cacheThis = this;
+        EditorHook.prototype.setTheme = function() {
           Editor.setTheme.apply(this, arguments);
-        }      
+        }
       },
       _addEditor: function() {
         this._fixStyle();
       },
       _fixStyle: function() {
         var root = this.root
-        this._styles.forEach(function (style) { 
-	  if(style) {
+        this._styles.forEach(function(style) {
+          if (style) {
             Polymer.dom(root).appendChild(style.cloneNode(true));
-	  }
-        })      
+          }
+        })
       }
     };
     return AceWidgetShadowDom;


### PR DESCRIPTION
Currently in ace-widget on Google Chrome, the more ace-widgets are in the dom, the more times `importCssString` will run when a new widget is loaded or modified and this number grows exponentially till the point where it runs over 500,000 times if you have 7 widgets in the dom.  This is because multiple dom listeners in `ace-widget-shadow-dom.html` are set up and the function is being fired too many times.  This commit limits `this._hookDom()` to only run the first time when it is needed.